### PR TITLE
Dev

### DIFF
--- a/frontend/src/auth/index.ts
+++ b/frontend/src/auth/index.ts
@@ -9,7 +9,11 @@ const USER_ID_KEY = 'dealfinder_user_id';
  */
 function decodeJwtPayload(token: string): Record<string, unknown> {
   try {
-    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    let base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    // Pad to a multiple of 4 characters so atob() always succeeds
+    while (base64.length % 4) {
+      base64 += '=';
+    }
     return JSON.parse(atob(base64));
   } catch {
     return {};

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { isAxiosError } from 'axios';
 import { getUserId, logout } from '../auth';
 import { useUpdatePreferences, useUserPreferences, useDeleteUser } from '../hooks';
 
@@ -12,7 +13,7 @@ export function PreferencesPage() {
   const navigate = useNavigate();
   const userId = getUserId() ?? '';
   const { data: existing } = useUserPreferences(userId);
-  const { mutate, isPending, isSuccess, isError } = useUpdatePreferences(userId);
+  const { mutate, isPending, isSuccess, isError, error: prefsError } = useUpdatePreferences(userId);
   const { mutate: doDelete, isPending: isDeleting } = useDeleteUser(userId);
 
   const [phoneNumber, setPhoneNumber] = useState('');
@@ -80,7 +81,10 @@ export function PreferencesPage() {
           {isSuccess && <p className="form-feedback form-feedback--ok">✓ Preferences saved.</p>}
           {isError && (
             <p className="form-feedback form-feedback--error">
-              Failed to save. Are you logged in?
+              Failed to save:{' '}
+              {isAxiosError(prefsError) && prefsError.response?.data?.detail
+                ? String(prefsError.response.data.detail)
+                : 'An unexpected error occurred.'}
             </p>
           )}
         </form>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -113,7 +113,13 @@ export function SearchPage() {
           setSavedIndexes((prev) => new Set([...prev, ...selected.map(({ i }) => i)]));
           setSaveMsg(`${newFeeds.length} feed${newFeeds.length !== 1 ? 's' : ''} saved ✔`);
         },
-        onError: () => setSaveMsg('Failed to save. Are you logged in?'),
+        onError: (err) => {
+          const detail =
+            isAxiosError(err) && err.response?.data?.detail
+              ? String(err.response.data.detail)
+              : 'An unexpected error occurred.';
+          setSaveMsg(`Failed to save: ${detail}`);
+        },
       },
     );
   }


### PR DESCRIPTION
Merge remote-tracking branch 'origin/main' into dev
fix(frontend): fix JWT decode padding and surface API error details

decodeJwtPayload did not add base64 padding before atob(), causing
getUserId() to silently return null when the JWT payload length was
not a multiple of 4. This made all user-scoped PUT requests fail
with an empty userId path parameter.

Also replace generic "Are you logged in?" error messages on
SearchPage and PreferencesPage with the actual API error detail.

Resolves #002

fix(frontend): fix JWT decode padding and surface API error details

decodeJwtPayload did not add base64 padding before atob(), causing
getUserId() to silently return null when the JWT payload length was
not a multiple of 4. This made all user-scoped PUT requests fail
with an empty userId path parameter.

Also replace generic "Are you logged in?" error messages on
SearchPage and PreferencesPage with the actual API error detail.

Resolves #002

Merge pull request #12 from Bytes0211/dev

Dev
Merge remote-tracking branch 'origin/main' into dev

git commit -m "fix(frontend): fix search layout, navbar logo, and error messaging

- Replace unstyled div cards with a table (Feed | Description |
  Quality Score headers); add all missing CSS classes
- Replace broken dealfinder_icon.png img with inline SVG price-tag icon
- Surface API error detail in search error message instead of
  hardcoded 'Error X001'
- Update AGENTS.md and developer journal (Session 5)

Merge pull request #10 from Bytes0211/dev

Dev
Merge remote-tracking branch 'origin/main' into dev

git commit -m "fix(frontend): surface API error detail in search error message

Replace hardcoded 'Error X001' with the actual detail returned by the
API (e.g. missing Tavily key, Tavily timeout, service unavailable).
Falls back to a generic message for non-HTTP errors.

Merge pull request #8 from Bytes0211/dev

Dev
chore(terraform): consolidate prod env into dev, remove old dev (#issue-consolidate-terraform-envs)

- Destroy old dev environment (97 AWS resources)
- Rename prod → dev as the single working environment
- Add tavily_api_key and sns_topic_arn to api module
- Add tavily_api_key to terraform.tfvars
- Delete prod environment directory

fix(frontend): replace diagnostic search error with ambiguous error code

Change 'Search failed. Is the API running?' to 'Search failed. Error X001.'

Co-Authored-By: Oz <oz-agent@warp.dev>

chore(terraform): configure Cognito Hosted UI domain for dev and export API outputs

- Add cognito_domain_prefix, cognito_callback_urls, cognito_logout_urls to dev api module
- Export api_endpoint, cognito_client_id, cognito_hosted_ui_domain from dev outputs
- Add frontend/.env.production with correct API GW URL, Cognito domain, and client ID

Co-Authored-By: Oz <oz-agent@warp.dev>

feat(terraform): add frontend outputs to dev environment

Co-Authored-By: Oz <oz-agent@warp.dev>

feat(terraform): add frontend module to dev environment

Co-Authored-By: Oz <oz-agent@warp.dev>

fix(terraform): remove from_email_address for COGNITO_DEFAULT email config

Co-Authored-By: Oz <oz-agent@warp.dev>

fix(terraform): add missing opening braces on variable blocks

Co-Authored-By: Oz <oz-agent@warp.dev>

Closes #13