### PR TITLE
feat(frontend,api,terraform): add in_stock badge, trend fields, domain labels, Bedrock IAM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Deal Finder is an AI-powered deal hunting system that discovers deals via RSS fe
 
 **Frontend (Session 14):** Preferences page now has an "Email Notifications" section: shows the user's Cognito email address and an opt-in checkbox that sets `notification_preferences.email = true`. MessengerAgent gates all SES dispatch on this flag. SES sandbox: `cottonbytes@gmail.com` verified as a sending/receiving identity.
 
+**Session 15:** Deal cards now show `in_stock` (Out of Stock badge), trend fields from `raw_data`, sale prices, and short domain labels (e.g. "amazon · View Deal ↗"). Bedrock extraction prompt includes `in_stock` boolean. API Lambda granted `bedrock:InvokeModel` IAM (search was silently failing). Search route aligned with watchlist agent (`buy price` suffix, `exclude_domains`). Match-card border fix (single wrapper border with `overflow: hidden`). Fixed `.env.production` with correct Cognito/API Gateway URLs. Added Lambda logging setup (`logging.getLogger().setLevel`).
+
 **Bedrock model config:** All model IDs are centralised in `config/bedrock_models.json`. Edit that file to change models for all agents and Terraform modules at once. Per-Lambda overrides are still possible via the `DEALFINDER_BEDROCK_MODEL_ID` environment variable.
 **Current Bedrock model:** `anthropic.claude-3-haiku-20240307-v1:0` (on-demand, agreement accepted)
 **Upgrade path:** Accept Claude 3.5 Haiku agreement in Bedrock console → update `config/bedrock_models.json` to `us.anthropic.claude-3-5-haiku-20241022-v1:0` → redeploy

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=https://4n1f2rgsc0.execute-api.us-east-1.amazonaws.com
-VITE_COGNITO_DOMAIN=dealfinder-dev.auth.us-east-1.amazoncognito.com
-VITE_COGNITO_CLIENT_ID=2t453r5kbijr0cpa2he68m28k0
-VITE_COGNITO_REDIRECT_URI=https://d3m3flgtpjwfg2.cloudfront.net/auth/callback
+VITE_API_BASE_URL=https://9fkhjqh2e4.execute-api.us-east-1.amazonaws.com
+VITE_COGNITO_DOMAIN=dealfinder-prod.auth.us-east-1.amazoncognito.com
+VITE_COGNITO_CLIENT_ID=5acg6u01qtn7g1lv0kg84294jp
+VITE_COGNITO_REDIRECT_URI=https://dk39ppkr0zciw.cloudfront.net/auth/callback

--- a/frontend/src/components/DealCard.tsx
+++ b/frontend/src/components/DealCard.tsx
@@ -9,6 +9,16 @@ function fmt(val: string | null, prefix = '$'): string {
   return val ? `${prefix}${parseFloat(val).toFixed(2)}` : '—';
 }
 
+/** Extract short domain label from a URL, e.g. "amazon" from "https://www.amazon.ca/..." */
+function shortDomain(url: string): string | null {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    return host.split('.')[0] || null;
+  } catch {
+    return null;
+  }
+}
+
 export function DealCard({ deal }: Props) {
   return (
     <div className={`deal-card${deal.is_high_value ? ' deal-card--hot' : ''}`}>
@@ -38,6 +48,7 @@ export function DealCard({ deal }: Props) {
       <div className="deal-card-footer">
         {deal.in_stock === false && <span className="badge badge--oos">Out of Stock</span>}
         <span className={`status status--${deal.status}`}>{deal.status}</span>
+        {shortDomain(deal.url) && <span className="deal-card-domain">{shortDomain(deal.url)}</span>}
         <a href={deal.url} target="_blank" rel="noopener noreferrer" className="btn btn-sm">
           View Deal ↗
         </a>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -175,6 +175,7 @@ h1 { font-size: 1.6rem; font-weight: 700; margin-top: 0; }
 .deal-card-meta { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
 .deal-card-meta-prices { display: inline-flex; align-items: baseline; gap: .4rem; margin-left: auto; }
 .deal-card-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; }
+.deal-card-domain { font-size: .7rem; color: var(--c-muted); }
 
 /* ── Badges & tags ────────────────────────────────── */
 .badge {
@@ -457,18 +458,24 @@ h1 { font-size: 1.6rem; font-weight: 700; margin-top: 0; }
 .search-actions { display: flex; gap: .75rem; flex-wrap: wrap; }
 
 /* ── Trend analysis ─────────────────────────────────────── */
-.match-card { display: flex; flex-direction: column; }
+.match-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+.match-card .deal-card { border: none; border-radius: 0; box-shadow: none; }
+.match-card:has(.deal-card--hot) { border-color: var(--c-hot); }
 .match-card-trend {
   padding: .4rem .75rem .5rem;
-  border: 1px solid var(--c-border);
-  border-top: none;
-  border-radius: 0 0 var(--radius) var(--radius);
+  border-top: 1px solid var(--c-border);
   background: var(--c-bg);
   display: flex;
   flex-direction: column;
   gap: .2rem;
 }
-.match-card .deal-card { border-radius: var(--radius) var(--radius) 0 0; }
 .trend-badge {
   display: inline-flex;
   align-items: center;

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -142,6 +142,15 @@ resource "aws_iam_role_policy" "api_inline" {
         Resource = "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${var.project_name}/${var.environment}/*"
       },
       {
+        Sid    = "Bedrock"
+        Effect = "Allow"
+        Action = ["bedrock:InvokeModel"]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/*",
+          "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+        ]
+      },
+      {
         Sid      = "SnsSubscribe"
         Effect   = "Allow"
         Action   = ["sns:Subscribe", "sns:Unsubscribe", "sns:ListSubscriptionsByTopic"]

--- a/src/dealfinder/agents/watchlist.py
+++ b/src/dealfinder/agents/watchlist.py
@@ -12,12 +12,17 @@ matching on deal titles — no API changes required on that side.
 import asyncio
 import hashlib
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import httpx
+
+logging.getLogger().setLevel(
+    getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO)
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dealfinder.agents.bedrock import BedrockSearchExtractor

--- a/src/dealfinder/api/routes/deals.py
+++ b/src/dealfinder/api/routes/deals.py
@@ -65,6 +65,7 @@ async def list_deals(
 
     items = []
     for deal in deals:
+        raw = deal.raw_data or {}
         items.append(DealResponse(
             id=deal.id,
             title=deal.title,
@@ -77,6 +78,15 @@ async def list_deals(
             brand=deal.brand,
             status=deal.status.value,
             source_name=deal.source.name if deal.source else None,
+            in_stock=raw.get("in_stock"),
+            trend=raw.get("trend"),
+            trend_confidence=raw.get("trend_confidence"),
+            price_trend=raw.get("price_trend"),
+            discount_frequency=raw.get("discount_frequency"),
+            stockouts_last_30_days=raw.get("stockouts_last_30_days"),
+            review_velocity=raw.get("review_velocity"),
+            competitor_activity=raw.get("competitor_activity"),
+            trend_summary=raw.get("trend_summary"),
         ))
 
     return DealListResponse(items=items, total=total, limit=limit, offset=offset)
@@ -118,6 +128,15 @@ async def top_deals(
             brand=deal.brand,
             status=deal.status.value,
             source_name=deal.source.name if deal.source else None,
+            in_stock=(deal.raw_data or {}).get("in_stock"),
+            trend=(deal.raw_data or {}).get("trend"),
+            trend_confidence=(deal.raw_data or {}).get("trend_confidence"),
+            price_trend=(deal.raw_data or {}).get("price_trend"),
+            discount_frequency=(deal.raw_data or {}).get("discount_frequency"),
+            stockouts_last_30_days=(deal.raw_data or {}).get("stockouts_last_30_days"),
+            review_velocity=(deal.raw_data or {}).get("review_velocity"),
+            competitor_activity=(deal.raw_data or {}).get("competitor_activity"),
+            trend_summary=(deal.raw_data or {}).get("trend_summary"),
         )
         for deal in deals
     ]
@@ -146,6 +165,7 @@ async def get_deal(deal_id: UUID, db: AsyncSession = Depends(get_db)) -> DealRes
     if not deal:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deal not found")
 
+    raw = deal.raw_data or {}
     return DealResponse(
         id=deal.id,
         title=deal.title,
@@ -158,4 +178,13 @@ async def get_deal(deal_id: UUID, db: AsyncSession = Depends(get_db)) -> DealRes
         brand=deal.brand,
         status=deal.status.value,
         source_name=deal.source.name if deal.source else None,
+        in_stock=raw.get("in_stock"),
+        trend=raw.get("trend"),
+        trend_confidence=raw.get("trend_confidence"),
+        price_trend=raw.get("price_trend"),
+        discount_frequency=raw.get("discount_frequency"),
+        stockouts_last_30_days=raw.get("stockouts_last_30_days"),
+        review_velocity=raw.get("review_velocity"),
+        competitor_activity=raw.get("competitor_activity"),
+        trend_summary=raw.get("trend_summary"),
     )

--- a/src/dealfinder/api/routes/search.py
+++ b/src/dealfinder/api/routes/search.py
@@ -43,11 +43,17 @@ async def _call_tavily(query: str, max_results: int, api_key: str) -> list[dict]
                 _TAVILY_API_URL,
                 json={
                     "api_key": api_key,
-                    "query": query,
+                    "query": f"{query} buy price",
                     "search_depth": "basic",
                     "max_results": max_results,
                     "include_answer": False,
                     "include_raw_content": False,
+                    "exclude_domains": [
+                        "youtube.com",
+                        "reddit.com",
+                        "twitter.com",
+                        "facebook.com",
+                    ],
                 },
             )
             response.raise_for_status()

--- a/src/dealfinder/db/alembic/versions/20260308_0001_007_purge_deals_for_reindexing.py
+++ b/src/dealfinder/db/alembic/versions/20260308_0001_007_purge_deals_for_reindexing.py
@@ -1,0 +1,50 @@
+"""Purge existing deals to allow WatchlistAgent rediscovery with in_stock field.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-03-08
+
+Changes:
+- DELETE all rows from the deals table.
+- The WatchlistAgent will rediscover deals on its next run, now with
+  the in_stock field populated from Bedrock enrichment.
+
+Background:
+  The in_stock boolean was added to the Bedrock extraction prompt after
+  existing deals were already persisted.  Deduplication by URL prevents
+  re-processing, so a one-time purge is needed to refresh all deal data.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Delete all deals to allow fresh rediscovery with in_stock metadata.
+
+    Returns:
+        None.
+    """
+    bind = op.get_bind()
+    # Delete dependent rows first to avoid FK constraint violations.
+    bind.execute(sa.text("DELETE FROM notifications"))
+    bind.execute(sa.text("DELETE FROM price_estimates"))
+    bind.execute(sa.text("DELETE FROM deals"))
+
+
+def downgrade() -> None:
+    """No-op: deleted deal data cannot be restored.
+
+    Returns:
+        None.
+    """
+    pass

--- a/src/dealfinder/db/alembic/versions/20260308_0002_008_purge_deals_for_in_stock.py
+++ b/src/dealfinder/db/alembic/versions/20260308_0002_008_purge_deals_for_in_stock.py
@@ -1,0 +1,39 @@
+"""Second purge — deals created between migration 007 and watchlist Lambda redeploy.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-03-08
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Delete deals created before in_stock Lambda deploy.
+
+    Returns:
+        None.
+    """
+    bind = op.get_bind()
+    bind.execute(sa.text("DELETE FROM notifications"))
+    bind.execute(sa.text("DELETE FROM price_estimates"))
+    bind.execute(sa.text("DELETE FROM deals"))
+
+
+def downgrade() -> None:
+    """No-op.
+
+    Returns:
+        None.
+    """
+    pass


### PR DESCRIPTION
## Session 15 Changes

- Add `in_stock` + 8 trend fields from `raw_data` to all `deals.py` endpoints
- Add short domain label to DealCard footer (e.g. 'amazon · View Deal')
- Fix match-card border gaps (single wrapper border with `overflow:hidden`)
- Add `bedrock:InvokeModel` IAM to API Lambda role (search was silently failing)
- Align search route Tavily params with watchlist agent (`buy price` suffix, `exclude_domains`)
- Add `logging.getLogger().setLevel()` to watchlist Lambda for CloudWatch visibility
- Fix `.env.production` with correct Cognito/API Gateway URLs
- Add Alembic migrations 007/008 to purge deals for reindexing with new fields

Co-Authored-By: Oz <oz-agent@warp.dev>