### PR TITLE
fix(frontend): fix match-card border clipping from scrollable grid overflow

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,7 +62,7 @@ a:hover { text-decoration: underline; }
 .deal-grid {
   max-height: calc(100vh - 14rem);
   overflow-y: auto;
-  padding-right: .5rem;
+  padding: 2px .5rem 2px 2px;
   scrollbar-width: thin;
   scrollbar-color: var(--c-border) transparent;
 }


### PR DESCRIPTION
## Fix

The `.deal-grid` scrollable container uses `overflow-y: auto`, which per CSS spec forces `overflow-x: auto` too. This clips 1px card borders flush against the container edge.

**Change:** `padding-right: .5rem` → `padding: 2px .5rem 2px 2px` on `.deal-grid`

See `github/ISSUES/005-match-card-border-clipping.md` for details.

Co-Authored-By: Oz <oz-agent@warp.dev>