### PR TITLE
test(api): expand regression coverage for deal pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Deal Finder is an AI-powered deal hunting system that discovers deals via RSS fe
 
 **Session 15:** Deal cards now show `in_stock` (Out of Stock badge), trend fields from `raw_data`, sale prices, and short domain labels (e.g. "amazon · View Deal ↗"). Bedrock extraction prompt includes `in_stock` boolean. API Lambda granted `bedrock:InvokeModel` IAM (search was silently failing). Search route aligned with watchlist agent (`buy price` suffix, `exclude_domains`). Match-card border fix (single wrapper border with `overflow: hidden`). Fixed `.env.production` with correct Cognito/API Gateway URLs. Added Lambda logging setup (`logging.getLogger().setLevel`).
 
+**Session 15b (Mar 8, 2026):** Hot deal card orange border fix — replaced CSS `:has(.deal-card--hot)` selector with direct `match-card--hot` class on the wrapper div in `FeedPage.tsx`. Used `outline: 2px solid #ff6b35` (hardcoded, high specificity) instead of `border-color` to survive browser dark mode overrides. Non-hot card borders remain invisible in both light/dark mode — tracked in `github/ISSUES/006-non-hot-deal-card-border-invisible.md`.
+
 **Bedrock model config:** All model IDs are centralised in `config/bedrock_models.json`. Edit that file to change models for all agents and Terraform modules at once. Per-Lambda overrides are still possible via the `DEALFINDER_BEDROCK_MODEL_ID` environment variable.
 **Current Bedrock model:** `anthropic.claude-3-haiku-20240307-v1:0` (on-demand, agreement accepted)
 **Upgrade path:** Accept Claude 3.5 Haiku agreement in Bedrock console → update `config/bedrock_models.json` to `us.anthropic.claude-3-5-haiku-20241022-v1:0` → redeploy
@@ -238,6 +240,7 @@ Feature flags keep idle costs at ~$4-10/month:
 - **Structure:** Tests grouped into classes (`TestDealRepository`, `TestUserRepository`). Each test has a docstring.
 - **Assertions:** Plain `assert` statements. Use `pytest.raises()` for exceptions.
 - **Run:** `uv run pytest tests/ -v`
+- **Regression smoke:** `uv run pytest tests/regression -q` before promoting builds to release branches
 
 ## Git Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Deal Finder is an AI-powered deal hunting system that discovers deals via RSS fe
 
 **Status:** Phase 7 complete and live in production. WatchlistAgent Lambda runs on a 30-minute EventBridge schedule, proactively discovering deals via Tavily search + Bedrock (Claude 3 Haiku) enrichment. SQLEnum casing bug and Bedrock Legacy model bug fixed (Session 12). Bedrock IAM policies updated to support cross-region inference profiles.
 
-**Frontend (Session 13):** "Matched Deals" feed page (renamed from Feed) supports per-watchlist-entry filter toggle (client-side keyword filtering), scrollable deal grid with sticky watchlist section, and consistent page spacing across all pages.
+**Frontend (Session 13):** "Matched Deals" feed page (renamed from Feed) supports per-watchlist-entry filter toggle (client-side keyword filtering), scrollable deal grid with sticky watchlist section, and consistent page spacing across all pages. Sales Price, Out-of-Stock status displayed.
 
 **Frontend (Session 14):** Preferences page now has an "Email Notifications" section: shows the user's Cognito email address and an opt-in checkbox that sets `notification_preferences.email = true`. MessengerAgent gates all SES dispatch on this flag. SES sandbox: `cottonbytes@gmail.com` verified as a sending/receiving identity.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ dealfinder/
 │   ├── db/
 │   │   ├── models.py              # SQLAlchemy ORM models (5 models, 3 enums)
 │   │   ├── connection.py          # Async engine and session management
-│   │   └── alembic/               # Database migrations (006 applied)
+│   │   └── alembic/               # Database migrations (008 applied)
 │   ├── data/
 │   │   └── repository.py          # Repository pattern (5 repository classes)
 │   └── search/
@@ -256,6 +256,10 @@ Feature flags keep idle dev costs at ~$4-10/month:
 - Updated Bedrock model to `anthropic.claude-3-haiku-20240307-v1:0`
 - Dual-ARN Bedrock IAM policy (foundation-model + inference-profile)
 - Frontend: watchlist feed filter, scrollable deal grid, consistent page spacing
+- Deal cards: `in_stock` badge, trend analysis panel, sale prices, short domain labels
+- Hot deal cards: orange outline border (CSS `outline` for dark mode resilience)
+- API Lambda granted `bedrock:InvokeModel` IAM; search route aligned with watchlist agent
+- Fixed `.env.production` Cognito/API Gateway URLs; restored Cognito callback URLs
 
 ## Documentation
 

--- a/developer/developer_journal.md
+++ b/developer/developer_journal.md
@@ -191,17 +191,46 @@ Automate proactive discovery with Tavily + Bedrock trend extraction, dedupe noti
 
 ---
 
+## Session 15b – Match Card Border Fixes (Mar 8, 2026)
+
+### Scope
+Fix hot deal card orange borders not rendering, and investigate non-hot card border visibility.
+
+### Key Activities
+- Replaced CSS `:has(.deal-card--hot)` selector with direct `match-card--hot` class applied in `FeedPage.tsx` JSX — `:has()` was unreliable across browsers.
+- Iterated through multiple CSS approaches: `border-color` (overridden by dark mode), `border` shorthand with hardcoded color (still overridden), finally `outline: 2px solid #ff6b35` with `outline-offset: -2px` — this survived browser dark mode.
+- Non-hot card borders (`#bfc5cc` outline) still invisible in both light and dark mode despite same `outline` technique. Created issue `github/ISSUES/006-non-hot-deal-card-border-invisible.md`.
+- Cleaned up branches: merged PR #17, deleted `fix/match-card-borders` locally and on remote, reset local `main` to `origin/main`.
+- Deployed frontend to S3/CloudFront with invalidation; verified hot deal orange borders in light mode.
+
+### Files Changed
+- `frontend/src/index.css` — `.match-card` outline fallback, `.match-card.match-card--hot` outline rule
+- `frontend/src/pages/FeedPage.tsx` — conditional `match-card--hot` class on wrapper div
+- `github/ISSUES/006-non-hot-deal-card-border-invisible.md` — new issue
+
+### Validation
+- Visual verification in light mode: orange borders on all hot deal cards confirmed.
+- Dark mode: hot deal borders work; non-hot borders still invisible (deferred to issue #006).
+
+### Lessons
+- Browser automatic dark mode can override CSS `border` and `border-color` properties, even with hardcoded colors and high specificity. `outline` is more resilient.
+- CSS `:has()` selector is unreliable for cross-browser production use — prefer applying classes directly in JSX.
+- Gray-colored outlines may blend with browser-applied dark mode backgrounds; high-contrast colors (like orange) survive.
+
+---
+
 ## Testing & Quality Summary
 
 | Suite                                   | Command                            | Result          |
 |-----------------------------------------|------------------------------------|-----------------|
-| Core unit (agents, data, API, notif)    | `uv run pytest tests/unit -q`      | 224 passed, 41 skipped |
+| Core unit (agents, data, API, notif)    | `uv run pytest tests/unit -q`      | 317 passed, 41 skipped |
+| Regression (pipeline smoke)             | `uv run pytest tests/regression -q` | 3 passed        |
 | Integration (pipeline, notifications)   | `uv run pytest tests/integration -q` | 18 passed       |
 | Frontend unit                           | `npm run test`                     | All green       |
 | Terraform validation                    | `terraform fmt`, `validate`, `plan` | Clean           |
 | Manual smoke                            | Step Functions, SES, Tavily mocks  | Success         |
 
-> Last comprehensive test suite run: March 12, 2026 (`224 passed, 41 skipped`).
+> Last comprehensive test suite run: March 12, 2026 (`317 passed, 41 skipped; regression suite 3 passed`). Regression pipeline smoke suite (`uv run pytest tests/regression -q`) now runs as part of our release verification checklist.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "email-validator>=2.3.0",
     "bcrypt>=4.0.0",
     "uvicorn>=0.41.0",
+    "moto>=5.1.22",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "email-validator>=2.3.0",
     "bcrypt>=4.0.0",
     "uvicorn>=0.41.0",
-    "moto>=5.1.22",
 ]
 
 [project.optional-dependencies]
@@ -64,6 +63,7 @@ asyncio_default_fixture_loop_scope = "function"
 dev = [
     "aiosqlite>=0.22.1",
     "httpx>=0.28.1",
+    "moto>=5.1.22",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
 ]

--- a/src/dealfinder/agents/bedrock.py
+++ b/src/dealfinder/agents/bedrock.py
@@ -28,12 +28,12 @@ class PriceEstimationResult:
     """Result from a Bedrock price estimation call.
 
     Attributes:
-        estimated_price: Estimated fair market retail value.
-        confidence: Confidence score in the estimate, 0.0–1.0.
-        range_low: Lower bound of the estimated price range.
-        range_high: Upper bound of the estimated price range.
-        model_id: Bedrock model ID used for inference.
-        inference_time_ms: Wall-clock inference duration in milliseconds.
+        estimated_price (Decimal): Estimated fair market retail value.
+        confidence (Decimal): Confidence score in the estimate, 0.0–1.0.
+        range_low (Decimal | None): Lower bound of the estimated price range.
+        range_high (Decimal | None): Upper bound of the estimated price range.
+        model_id (str): Bedrock model ID used for inference.
+        inference_time_ms (int): Wall-clock inference duration in milliseconds.
     """
 
     estimated_price: Decimal
@@ -133,12 +133,14 @@ class BedrockPriceEstimator:
         if description:
             lines.append(f"Description: {_sanitize(description)}")
         lines.append(f"Current sale price: ${sale_price}")
-        lines.extend([
-            "",
-            "Respond with ONLY a JSON object (no markdown, no explanation):",
-            '{"estimated_price": <number>, "confidence": <0.0-1.0>,'
-            ' "range_low": <number>, "range_high": <number>, "reasoning": "<brief>"}',
-        ])
+        lines.extend(
+            [
+                "",
+                "Respond with ONLY a JSON object (no markdown, no explanation):",
+                '{"estimated_price": <number>, "confidence": <0.0-1.0>,'
+                ' "range_low": <number>, "range_high": <number>, "reasoning": "<brief>"}',
+            ]
+        )
         return "\n".join(lines)
 
     def _parse_response(self, response_text: str) -> dict:
@@ -147,14 +149,14 @@ class BedrockPriceEstimator:
         Handles responses that wrap JSON in markdown code fences.
 
         Args:
-            response_text: Raw text content from the Claude response.
+            response_text (str): Raw text content from the Claude response.
 
         Returns:
-            Parsed response dict with at minimum estimated_price and confidence.
+            dict: Parsed response containing at least ``estimated_price`` and ``confidence``.
 
         Raises:
-            ValueError: If no JSON object is found or required fields are missing.
-            ValueError: If confidence is outside the 0.0–1.0 range.
+            ValueError: If no JSON object is found, required fields are missing, or the
+                confidence value falls outside the 0.0–1.0 range.
         """
         start = response_text.find("{")
         if start == -1:
@@ -202,12 +204,14 @@ class BedrockPriceEstimator:
             ValueError: If the Claude response cannot be parsed as valid price data.
         """
         prompt = self._build_prompt(title, sale_price, description, brand)
-        body = json.dumps({
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": 256,
-            "temperature": 0.1,
-            "messages": [{"role": "user", "content": prompt}],
-        })
+        body = json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 256,
+                "temperature": 0.1,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+        )
 
         start_ms = int(time.time() * 1000)
 
@@ -291,14 +295,16 @@ class BedrockSearchExtractor:
         return self._client
 
     def _build_extraction_prompt(self, results: list[dict], include_trends: bool = False) -> str:
-        """Build a structured extraction + quality scoring prompt for Claude.
+        """Build a structured extraction and quality-scoring prompt for Claude.
 
         Args:
-            results: List of raw Tavily result dicts with title, url, content keys.
-            include_trends: If True, append trend analysis fields to the output schema.
+            results (list[dict]): Raw Tavily result dictionaries with ``title``, ``url``,
+                and ``content`` keys.
+            include_trends (bool): Whether to append trend analysis fields to the output
+                schema.
 
         Returns:
-            Formatted prompt string ready to be sent to Claude.
+            str: Formatted prompt string ready to be sent to Claude.
         """
         condensed = [
             {
@@ -314,7 +320,7 @@ class BedrockSearchExtractor:
             "For each result return:\n"
             "- title: Clean product name (remove store names and marketing filler)\n"
             "- url: The product URL exactly as provided\n"
-            "- current_price: Current sale price as a string (e.g. \"$279.99\") or null if not found. "
+            '- current_price: Current sale price as a string (e.g. "$279.99") or null if not found. '
             "If multiple prices are listed, use the lowest retail price.\n"
             "- in_stock: true if the product appears to be available/in stock, false if out of stock or unavailable\n"
             "- quality_score: Float 0.0\u201310.0 rating the deal quality\n"
@@ -329,13 +335,13 @@ class BedrockSearchExtractor:
 
         if include_trends:
             fields += (
-                "\n- trend: \"upward\" | \"downward\" | \"stable\" \u2014 inferred demand trend\n"
+                '\n- trend: "upward" | "downward" | "stable" \u2014 inferred demand trend\n'
                 "- trend_confidence: Float 0.0\u20131.0 \u2014 confidence in trend assessment\n"
-                "- price_trend: \"increasing\" | \"decreasing\" | \"stable\"\n"
-                "- discount_frequency: \"low\" | \"medium\" | \"high\" \u2014 how often this product is discounted\n"
+                '- price_trend: "increasing" | "decreasing" | "stable"\n'
+                '- discount_frequency: "low" | "medium" | "high" \u2014 how often this product is discounted\n'
                 "- stockouts_last_30_days: Integer 0\u201310 estimate of stockout events, or null if unknown\n"
-                "- review_velocity: \"low\" | \"medium\" | \"high\" \u2014 rate of new customer reviews\n"
-                "- competitor_activity: \"stable\" | \"increasing\" | \"decreasing\"\n"
+                '- review_velocity: "low" | "medium" | "high" \u2014 rate of new customer reviews\n'
+                '- competitor_activity: "stable" | "increasing" | "decreasing"\n'
                 "- trend_summary: Max 20-word explanation of the overall demand trend"
             )
             example += (
@@ -360,11 +366,13 @@ class BedrockSearchExtractor:
         Falls back to minimal results (title/url only) if parsing fails.
 
         Args:
-            response_text: Raw Claude output.
-            original: Original Tavily results used as fallback source for title/url.
+            response_text (str): Raw Claude output.
+            original (list[dict]): Original Tavily results used as a fallback source for
+                ``title`` and ``url``.
 
         Returns:
-            List of dicts with title, url, current_price, quality_score, quality_reason keys.
+            list[dict]: Enriched results containing ``title``, ``url``, ``current_price``,
+            ``quality_score``, and ``quality_reason`` keys.
         """
         start = response_text.find("[")
         if start != -1:
@@ -376,8 +384,13 @@ class BedrockSearchExtractor:
                 pass
         logger.warning("BedrockSearchExtractor: failed to parse Claude response; using fallbacks")
         return [
-            {"title": r.get("title", ""), "url": r.get("url", ""),
-             "current_price": None, "quality_score": None, "quality_reason": None}
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "current_price": None,
+                "quality_score": None,
+                "quality_reason": None,
+            }
             for r in original
         ]
 
@@ -404,12 +417,14 @@ class BedrockSearchExtractor:
         prompt = self._build_extraction_prompt(results, include_trends=include_trends)
         # Trend fields add ~150 tokens per result; 4096 comfortably fits 10 results.
         max_tokens = 4096 if include_trends else 1024
-        body = json.dumps({
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": max_tokens,
-            "temperature": 0.1,
-            "messages": [{"role": "user", "content": prompt}],
-        })
+        body = json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": max_tokens,
+                "temperature": 0.1,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+        )
 
         try:
             response = self.client.invoke_model(

--- a/src/dealfinder/agents/config.py
+++ b/src/dealfinder/agents/config.py
@@ -21,12 +21,9 @@ _CONFIG_FILE = Path(__file__).resolve().parents[3] / "config" / "bedrock_models.
 def _load_default_model_id() -> str:
     """Load the default Bedrock model ID from config/bedrock_models.json.
 
-    Falls back to a hardcoded model ID if the config file is missing or
-    cannot be parsed (e.g. inside a Lambda deployment package that does
-    not include the config directory).
-
     Returns:
-        Bedrock model ID string.
+        str: Default Bedrock model ID, falling back to a hardcoded value when the
+        configuration file is missing or invalid.
     """
     try:
         data = json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
@@ -37,18 +34,18 @@ def _load_default_model_id() -> str:
 
 
 class AgentConfig(BaseSettings):
-    """Configuration for Lambda agent functions.
+    """Configuration values for Lambda-based agents.
 
     Attributes:
-        discount_threshold: Minimum discount percentage to flag a deal as high value.
-        bedrock_region: AWS region used for Bedrock API calls.
-        bedrock_model_id: Bedrock model identifier for Claude. Loaded from
-            config/bedrock_models.json by default; override via
-            DEALFINDER_BEDROCK_MODEL_ID env var.
-        notification_queue_url: SQS URL for the notification-dispatch queue.
-        ses_sender_email: Verified SES sender address for email notifications.
-        sns_topic_arn: ARN of the SNS topic for deal alert fan-out.
-        dedup_table_name: DynamoDB table used for 24-hour notification deduplication.
+        discount_threshold (float): Minimum discount percentage that marks a deal as high value.
+        bedrock_region (str): AWS region used for Bedrock API invocations.
+        bedrock_model_id (str): Default Bedrock model identifier for Claude. Loaded from
+            ``config/bedrock_models.json`` unless overridden via ``DEALFINDER_BEDROCK_MODEL_ID``.
+        notification_queue_url (str): SQS URL for the notification-dispatch queue.
+        tavily_api_key (str): API key used by the Watchlist agent to query Tavily.
+        ses_sender_email (str): Verified SES sender address for email notifications.
+        sns_topic_arn (str): ARN of the SNS topic for deal alert fan-out.
+        dedup_table_name (str): DynamoDB table used for 24-hour notification deduplication.
     """
 
     model_config = SettingsConfigDict(

--- a/tests/regression/__init__.py
+++ b/tests/regression/__init__.py
@@ -1,0 +1,1 @@
+"""Regression test suite package for end-to-end deal pipeline scenarios."""

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -20,13 +20,6 @@ from .jsonb_patch import enable_sqlite_jsonb_support
 
 """Shared fixtures for regression test suite covering the deal pipeline."""
 
-FAKE_AWS_ENVIRONMENT = {
-    "sns_topic_arn": "arn:aws:sns:us-east-1:000000000000:regression-deal-events",
-    "sqs_queue_url": "https://sqs.us-east-1.amazonaws.com/000000000000/regression-deal-queue",
-    "dynamodb_table": "deal-notification-state",
-    "verified_email": "regression@example.com",
-}
-
 
 @pytest_asyncio.fixture
 async def sqlite_engine() -> AsyncIterator[AsyncEngine]:
@@ -70,27 +63,3 @@ async def db_session(
     finally:
         await session.rollback()
         await session.close()
-
-
-@pytest.fixture(scope="session")
-def regression_aws_environment() -> dict[str, str]:
-    return FAKE_AWS_ENVIRONMENT.copy()
-
-
-@pytest.fixture
-def pipeline_env_variables(regression_aws_environment: dict[str, str]) -> Iterator[dict[str, str]]:
-    overrides = {
-        "DEALFINDER_SNS_TOPIC_ARN": regression_aws_environment["sns_topic_arn"],
-        "DEALFINDER_SQS_QUEUE_URL": regression_aws_environment["sqs_queue_url"],
-        "DEALFINDER_DYNAMODB_TABLE": regression_aws_environment["dynamodb_table"],
-    }
-    previous = {key: os.environ.get(key) for key in overrides}
-    os.environ.update(overrides)
-    try:
-        yield regression_aws_environment
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from dealfinder.db.models import Base
+
+from .jsonb_patch import enable_sqlite_jsonb_support
+
+"""Shared fixtures for regression test suite covering the deal pipeline."""
+
+FAKE_AWS_ENVIRONMENT = {
+    "sns_topic_arn": "arn:aws:sns:us-east-1:000000000000:regression-deal-events",
+    "sqs_queue_url": "https://sqs.us-east-1.amazonaws.com/000000000000/regression-deal-queue",
+    "dynamodb_table": "deal-notification-state",
+    "verified_email": "regression@example.com",
+}
+
+
+@pytest_asyncio.fixture
+async def sqlite_engine() -> AsyncIterator[AsyncEngine]:
+    enable_sqlite_jsonb_support()
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+        poolclass=StaticPool,
+    )
+
+    def _enable_foreign_keys(dbapi_connection, connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.close()
+
+    event.listen(engine.sync_engine, "connect", _enable_foreign_keys)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def regression_session_factory(
+    sqlite_engine: AsyncEngine,
+) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(sqlite_engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def db_session(
+    regression_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[AsyncSession]:
+    session = regression_session_factory()
+    try:
+        yield session
+    finally:
+        await session.rollback()
+        await session.close()
+
+
+@pytest.fixture(scope="session")
+def regression_aws_environment() -> dict[str, str]:
+    return FAKE_AWS_ENVIRONMENT.copy()
+
+
+@pytest.fixture
+def pipeline_env_variables(regression_aws_environment: dict[str, str]) -> Iterator[dict[str, str]]:
+    overrides = {
+        "DEALFINDER_SNS_TOPIC_ARN": regression_aws_environment["sns_topic_arn"],
+        "DEALFINDER_SQS_QUEUE_URL": regression_aws_environment["sqs_queue_url"],
+        "DEALFINDER_DYNAMODB_TABLE": regression_aws_environment["dynamodb_table"],
+    }
+    previous = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield regression_aws_environment
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import os
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 
 import pytest
 import pytest_asyncio

--- a/tests/regression/jsonb_patch.py
+++ b/tests/regression/jsonb_patch.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""
+SQLite JSONB compilation helper for regression tests.
+
+The production models use PostgreSQL's JSONB columns. When we recreate the
+schema against in-memory SQLite during tests, SQLAlchemy needs to know how to
+compile JSONB for the SQLite dialect. Importing this module once (typically in
+pytest fixtures) registers a minimal compiler hook that maps JSONB columns to
+SQLite's native JSON type so metadata creation succeeds.
+"""
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_for_sqlite(element: JSONB, compiler, **_: object) -> str:
+    """Render PostgreSQL JSONB columns as SQLite JSON."""
+    return "JSON"
+
+
+def enable_sqlite_jsonb_support() -> None:
+    """Backward-compatible no-op helper for call sites that expect a callable."""
+    # Import side effects already registered the compiler patch.
+    return None

--- a/tests/regression/test_deal_pipeline.py
+++ b/tests/regression/test_deal_pipeline.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 from decimal import Decimal
 from types import SimpleNamespace
 from uuid import uuid4
 
+import boto3
 import pytest
+from moto import mock_aws
 from sqlalchemy import text
 
 from dealfinder.agents.config import AgentConfig
@@ -15,15 +18,6 @@ from dealfinder.data.repository import DealRepository
 from dealfinder.db.models import Deal, DealSource, DealStatus
 
 pytestmark = pytest.mark.asyncio
-
-
-class _StubQueue:
-    def __init__(self) -> None:
-        self.messages: list[dict[str, str]] = []
-
-    def send_message(self, QueueUrl: str, MessageBody: str) -> dict[str, str]:
-        self.messages.append({"QueueUrl": QueueUrl, "MessageBody": MessageBody})
-        return {"MessageId": "stubbed-message"}
 
 
 class _SessionContext:
@@ -102,12 +96,13 @@ async def _create_pipeline_deal(session, source: DealSource, title: str, link: s
     return deal
 
 
-async def _patch_evaluator_dependencies(
+def _patch_evaluator_dependencies(
     monkeypatch,
     regression_session_factory,
-    queue_stub: _StubQueue,
     saved_feeds: list[dict[str, str]],
 ):
+    """Patch evaluator dependencies to use in-memory session and test feeds."""
+
     class _DummyUser:
         def __init__(self, feeds: list[dict[str, str]]) -> None:
             self.id = uuid4()
@@ -125,10 +120,6 @@ async def _patch_evaluator_dependencies(
         "dealfinder.agents.evaluator.get_async_session",
         lambda: _SessionContext(regression_session_factory),
         raising=False,
-    )
-    monkeypatch.setattr(
-        "dealfinder.agents.evaluator.boto3.client",
-        lambda *_args, **_kwargs: queue_stub,
     )
 
 
@@ -166,25 +157,57 @@ async def test_high_value_deal_triggers_notification_queue(
         await session.commit()
         deal_id = deal.id
 
-    queue_stub = _StubQueue()
-    saved_feeds = [{"id": "feed-laptop", "query": "Mega Laptop"}]
-    await _patch_evaluator_dependencies(
-        monkeypatch, regression_session_factory, queue_stub, saved_feeds
-    )
+    result = None
+    messages: list[dict] = []
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="regression-deal-queue")["QueueUrl"]
 
-    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=20.0)
-    evaluator = EvaluatorAgent(config=config)
-    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("400"))
+        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+        table_name = pipeline_env_variables["dynamodb_table"]
+        try:
+            dynamodb.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        except dynamodb.exceptions.ResourceInUseException:
+            pass
+        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
 
-    result = await evaluator.evaluate_deal(deal_id)
+        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
+        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
+        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
+        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
 
+        try:
+            saved_feeds = [{"id": "feed-laptop", "query": "Mega Laptop"}]
+            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+            config = _build_agent_config(queue_url, discount_threshold=20.0)
+            evaluator = EvaluatorAgent(config=config)
+            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("400"))
+            result = await evaluator.evaluate_deal(deal_id)
+            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+                "Messages", []
+            )
+        finally:
+            if previous_sqs is None:
+                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
+            else:
+                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
+            if previous_table is None:
+                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
+            else:
+                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+
+    assert result is not None
     assert result["status"] == "evaluated"
     assert result["is_high_value"] is True
     assert result["discount_percentage"] == pytest.approx(75.0, rel=1e-6)
-    assert queue_stub.messages, "Expected SQS message for high-value deal"
-    message = queue_stub.messages[0]
-    assert message["QueueUrl"] == pipeline_env_variables["sqs_queue_url"]
-    assert json.loads(message["MessageBody"])["deal_id"] == str(deal_id)
+    assert len(messages) == 1, "Expected SQS message for high-value deal"
+    body = json.loads(messages[0]["Body"])
+    assert body["deal_id"] == str(deal_id)
     assert result["matched_feed_pairs"]
     refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
     assert refreshed_deal.status == DealStatus.EVALUATED
@@ -210,22 +233,55 @@ async def test_sub_threshold_deal_skips_notification_queue(
         await session.commit()
         deal_id = deal.id
 
-    queue_stub = _StubQueue()
-    saved_feeds = [{"id": "feed-mouse", "query": "Office Chair"}]
-    await _patch_evaluator_dependencies(
-        monkeypatch, regression_session_factory, queue_stub, saved_feeds
-    )
+    result = None
+    messages: list[dict] = []
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="regression-deal-queue-low")["QueueUrl"]
 
-    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=20.0)
-    evaluator = EvaluatorAgent(config=config)
-    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("105"))
+        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+        table_name = pipeline_env_variables["dynamodb_table"]
+        try:
+            dynamodb.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        except dynamodb.exceptions.ResourceInUseException:
+            pass
+        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
 
-    result = await evaluator.evaluate_deal(deal_id)
+        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
+        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
+        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
+        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
 
+        try:
+            saved_feeds = [{"id": "feed-mouse", "query": "Office Chair"}]
+            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+            config = _build_agent_config(queue_url, discount_threshold=20.0)
+            evaluator = EvaluatorAgent(config=config)
+            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("105"))
+            result = await evaluator.evaluate_deal(deal_id)
+            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+                "Messages", []
+            )
+        finally:
+            if previous_sqs is None:
+                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
+            else:
+                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
+            if previous_table is None:
+                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
+            else:
+                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+
+    assert result is not None
     assert result["status"] == "evaluated"
     assert result["is_high_value"] is False
     assert result["matched_feed_pairs"] == []
-    assert queue_stub.messages == [], "No SQS messages should be sent for sub-threshold deals"
+    assert messages == [], "No SQS messages should be sent for sub-threshold deals"
     refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
     assert refreshed_deal.status == DealStatus.EVALUATED
     assert refreshed_deal.is_high_value is False
@@ -251,26 +307,59 @@ async def test_watchlist_dedup_sends_single_notification(
         await session.commit()
         deal_id = deal.id
 
-    queue_stub = _StubQueue()
-    saved_feeds = [
-        {"id": "feed-gaming-1", "query": "Ultimate Gaming"},
-        {"id": "feed-gaming-2", "query": "Gaming Rig Ultimate"},
-        {"id": "feed-miss", "query": "Office Chair"},
-    ]
-    await _patch_evaluator_dependencies(
-        monkeypatch, regression_session_factory, queue_stub, saved_feeds
-    )
+    result = None
+    messages: list[dict] = []
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="regression-deal-queue-watch")["QueueUrl"]
 
-    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=25.0)
-    evaluator = EvaluatorAgent(config=config)
-    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("1500"))
+        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+        table_name = pipeline_env_variables["dynamodb_table"]
+        try:
+            dynamodb.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        except dynamodb.exceptions.ResourceInUseException:
+            pass
+        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
 
-    result = await evaluator.evaluate_deal(deal_id)
+        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
+        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
+        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
+        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
 
+        try:
+            saved_feeds = [
+                {"id": "feed-gaming-1", "query": "Ultimate Gaming"},
+                {"id": "feed-gaming-2", "query": "Gaming Rig Ultimate"},
+                {"id": "feed-miss", "query": "Office Chair"},
+            ]
+            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+            config = _build_agent_config(queue_url, discount_threshold=25.0)
+            evaluator = EvaluatorAgent(config=config)
+            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("1500"))
+            result = await evaluator.evaluate_deal(deal_id)
+            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+                "Messages", []
+            )
+        finally:
+            if previous_sqs is None:
+                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
+            else:
+                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
+            if previous_table is None:
+                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
+            else:
+                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+
+    assert result is not None
     assert result["is_high_value"] is True
     assert len(result["matched_feed_pairs"]) == 2
-    assert len(queue_stub.messages) == 1, "Queue should receive a single message per deal"
-    message_body = json.loads(queue_stub.messages[0]["MessageBody"])
+    assert len(messages) == 1, "Queue should receive a single message per deal"
+    message_body = json.loads(messages[0]["Body"])
     assert message_body["deal_id"] == str(deal_id)
     refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
     assert refreshed_deal.is_high_value is True

--- a/tests/regression/test_deal_pipeline.py
+++ b/tests/regression/test_deal_pipeline.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import boto3
 import pytest
 from moto import mock_aws
-from sqlalchemy import text
 
 from dealfinder.agents.config import AgentConfig
 from dealfinder.agents.evaluator import EvaluatorAgent
@@ -43,11 +42,11 @@ def _make_feed(*entries: dict) -> SimpleNamespace:
 
 
 def _build_agent_config(queue_url: str, discount_threshold: float = 20.0) -> AgentConfig:
-    config = AgentConfig()
-    config.notification_queue_url = queue_url
-    config.discount_threshold = discount_threshold
-    config.bedrock_region = "us-east-1"
-    return config
+    return AgentConfig(
+        notification_queue_url=queue_url,
+        discount_threshold=discount_threshold,
+        bedrock_region="us-east-1",
+    )
 
 
 def _prepare_source(session, name: str, url: str) -> DealSource:

--- a/tests/regression/test_deal_pipeline.py
+++ b/tests/regression/test_deal_pipeline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from decimal import Decimal
 from types import SimpleNamespace
 from uuid import uuid4
@@ -131,20 +130,11 @@ async def _verify_deal_status(regression_session_factory, deal_id):
         return refreshed
 
 
-async def _reset_tables(regression_session_factory):
-    async with _SessionContext(regression_session_factory) as session:
-        await session.execute(text("DELETE FROM notifications"))
-        await session.execute(text("DELETE FROM price_estimates"))
-        await session.execute(text("DELETE FROM deals"))
-        await session.execute(text("DELETE FROM deal_sources"))
-
-
 async def test_high_value_deal_triggers_notification_queue(
     regression_session_factory,
     monkeypatch,
-    pipeline_env_variables,
 ):
-    await _reset_tables(regression_session_factory)
+
     async with _SessionContext(regression_session_factory) as session:
         source = _prepare_source(session, "Regression Feed HV", "https://example.com/feed/high")
         await session.commit()
@@ -163,43 +153,15 @@ async def test_high_value_deal_triggers_notification_queue(
         sqs = boto3.client("sqs", region_name="us-east-1")
         queue_url = sqs.create_queue(QueueName="regression-deal-queue")["QueueUrl"]
 
-        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-        table_name = pipeline_env_variables["dynamodb_table"]
-        try:
-            dynamodb.create_table(
-                TableName=table_name,
-                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
-                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
-        except dynamodb.exceptions.ResourceInUseException:
-            pass
-        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
-
-        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
-        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
-        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
-        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
-
-        try:
-            saved_feeds = [{"id": "feed-laptop", "query": "Mega Laptop"}]
-            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
-            config = _build_agent_config(queue_url, discount_threshold=20.0)
-            evaluator = EvaluatorAgent(config=config)
-            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("400"))
-            result = await evaluator.evaluate_deal(deal_id)
-            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
-                "Messages", []
-            )
-        finally:
-            if previous_sqs is None:
-                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
-            else:
-                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
-            if previous_table is None:
-                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
-            else:
-                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+        saved_feeds = [{"id": "feed-laptop", "query": "Mega Laptop"}]
+        _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+        config = _build_agent_config(queue_url, discount_threshold=20.0)
+        evaluator = EvaluatorAgent(config=config)
+        evaluator.estimator = _prepare_estimator(estimated_price=Decimal("400"))
+        result = await evaluator.evaluate_deal(deal_id)
+        messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+            "Messages", []
+        )
 
     assert result is not None
     assert result["status"] == "evaluated"
@@ -218,9 +180,8 @@ async def test_high_value_deal_triggers_notification_queue(
 async def test_sub_threshold_deal_skips_notification_queue(
     regression_session_factory,
     monkeypatch,
-    pipeline_env_variables,
 ):
-    await _reset_tables(regression_session_factory)
+
     async with _SessionContext(regression_session_factory) as session:
         source = _prepare_source(session, "Regression Feed LV", "https://example.com/feed/low")
         await session.commit()
@@ -239,43 +200,15 @@ async def test_sub_threshold_deal_skips_notification_queue(
         sqs = boto3.client("sqs", region_name="us-east-1")
         queue_url = sqs.create_queue(QueueName="regression-deal-queue-low")["QueueUrl"]
 
-        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-        table_name = pipeline_env_variables["dynamodb_table"]
-        try:
-            dynamodb.create_table(
-                TableName=table_name,
-                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
-                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
-        except dynamodb.exceptions.ResourceInUseException:
-            pass
-        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
-
-        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
-        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
-        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
-        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
-
-        try:
-            saved_feeds = [{"id": "feed-mouse", "query": "Office Chair"}]
-            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
-            config = _build_agent_config(queue_url, discount_threshold=20.0)
-            evaluator = EvaluatorAgent(config=config)
-            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("105"))
-            result = await evaluator.evaluate_deal(deal_id)
-            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
-                "Messages", []
-            )
-        finally:
-            if previous_sqs is None:
-                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
-            else:
-                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
-            if previous_table is None:
-                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
-            else:
-                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+        saved_feeds = [{"id": "feed-mouse", "query": "Office Chair"}]
+        _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+        config = _build_agent_config(queue_url, discount_threshold=20.0)
+        evaluator = EvaluatorAgent(config=config)
+        evaluator.estimator = _prepare_estimator(estimated_price=Decimal("105"))
+        result = await evaluator.evaluate_deal(deal_id)
+        messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+            "Messages", []
+        )
 
     assert result is not None
     assert result["status"] == "evaluated"
@@ -292,9 +225,8 @@ async def test_sub_threshold_deal_skips_notification_queue(
 async def test_watchlist_dedup_sends_single_notification(
     regression_session_factory,
     monkeypatch,
-    pipeline_env_variables,
 ):
-    await _reset_tables(regression_session_factory)
+
     async with _SessionContext(regression_session_factory) as session:
         source = _prepare_source(session, "Regression Feed WL", "https://example.com/feed/watch")
         await session.commit()
@@ -313,47 +245,19 @@ async def test_watchlist_dedup_sends_single_notification(
         sqs = boto3.client("sqs", region_name="us-east-1")
         queue_url = sqs.create_queue(QueueName="regression-deal-queue-watch")["QueueUrl"]
 
-        dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-        table_name = pipeline_env_variables["dynamodb_table"]
-        try:
-            dynamodb.create_table(
-                TableName=table_name,
-                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
-                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
-        except dynamodb.exceptions.ResourceInUseException:
-            pass
-        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
-
-        previous_sqs = os.environ.get("DEALFINDER_SQS_QUEUE_URL")
-        previous_table = os.environ.get("DEALFINDER_DYNAMODB_TABLE")
-        os.environ["DEALFINDER_SQS_QUEUE_URL"] = queue_url
-        os.environ["DEALFINDER_DYNAMODB_TABLE"] = table_name
-
-        try:
-            saved_feeds = [
-                {"id": "feed-gaming-1", "query": "Ultimate Gaming"},
-                {"id": "feed-gaming-2", "query": "Gaming Rig Ultimate"},
-                {"id": "feed-miss", "query": "Office Chair"},
-            ]
-            _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
-            config = _build_agent_config(queue_url, discount_threshold=25.0)
-            evaluator = EvaluatorAgent(config=config)
-            evaluator.estimator = _prepare_estimator(estimated_price=Decimal("1500"))
-            result = await evaluator.evaluate_deal(deal_id)
-            messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
-                "Messages", []
-            )
-        finally:
-            if previous_sqs is None:
-                os.environ.pop("DEALFINDER_SQS_QUEUE_URL", None)
-            else:
-                os.environ["DEALFINDER_SQS_QUEUE_URL"] = previous_sqs
-            if previous_table is None:
-                os.environ.pop("DEALFINDER_DYNAMODB_TABLE", None)
-            else:
-                os.environ["DEALFINDER_DYNAMODB_TABLE"] = previous_table
+        saved_feeds = [
+            {"id": "feed-gaming-1", "query": "Ultimate Gaming"},
+            {"id": "feed-gaming-2", "query": "Gaming Rig Ultimate"},
+            {"id": "feed-miss", "query": "Office Chair"},
+        ]
+        _patch_evaluator_dependencies(monkeypatch, regression_session_factory, saved_feeds)
+        config = _build_agent_config(queue_url, discount_threshold=25.0)
+        evaluator = EvaluatorAgent(config=config)
+        evaluator.estimator = _prepare_estimator(estimated_price=Decimal("1500"))
+        result = await evaluator.evaluate_deal(deal_id)
+        messages = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10).get(
+            "Messages", []
+        )
 
     assert result is not None
     assert result["is_high_value"] is True

--- a/tests/regression/test_deal_pipeline.py
+++ b/tests/regression/test_deal_pipeline.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from dealfinder.agents.config import AgentConfig
+from dealfinder.agents.evaluator import EvaluatorAgent
+from dealfinder.agents.scanner import ScannerAgent
+from dealfinder.data.repository import DealRepository
+from dealfinder.db.models import Deal, DealSource, DealStatus
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StubQueue:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, str]] = []
+
+    def send_message(self, QueueUrl: str, MessageBody: str) -> dict[str, str]:
+        self.messages.append({"QueueUrl": QueueUrl, "MessageBody": MessageBody})
+        return {"MessageId": "stubbed-message"}
+
+
+class _SessionContext:
+    def __init__(self, factory) -> None:
+        self._factory = factory
+        self._session = None
+
+    async def __aenter__(self):
+        self._session = self._factory()
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if not self._session:
+            return
+        if exc_type:
+            await self._session.rollback()
+        else:
+            await self._session.commit()
+        await self._session.close()
+
+
+def _make_feed(*entries: dict) -> SimpleNamespace:
+    return SimpleNamespace(entries=list(entries), bozo=False, bozo_exception=None)
+
+
+def _build_agent_config(queue_url: str, discount_threshold: float = 20.0) -> AgentConfig:
+    config = AgentConfig()
+    config.notification_queue_url = queue_url
+    config.discount_threshold = discount_threshold
+    config.bedrock_region = "us-east-1"
+    return config
+
+
+def _prepare_source(session, name: str, url: str) -> DealSource:
+    source = DealSource(name=name, url=url, is_active=True)
+    session.add(source)
+    return source
+
+
+def _prepare_estimator(estimated_price: Decimal, confidence: Decimal = Decimal("0.90")):
+    estimation = SimpleNamespace(
+        model_id="anthropic.mock",
+        estimated_price=estimated_price,
+        confidence=confidence,
+        range_low=estimated_price * Decimal("0.9"),
+        range_high=estimated_price * Decimal("1.1"),
+        inference_time_ms=1234,
+    )
+
+    class _Estimator:
+        def estimate_price(self, **_) -> SimpleNamespace:
+            return estimation
+
+    return _Estimator()
+
+
+async def _create_pipeline_deal(session, source: DealSource, title: str, link: str) -> Deal:
+    feed = _make_feed(
+        {
+            "id": f"{title}-id",
+            "title": title,
+            "link": link,
+            "summary": "Regression pipeline entry",
+            "published": "2026-03-07T00:00:00Z",
+            "tags": [{"term": "electronics"}],
+        }
+    )
+    scanner = ScannerAgent()
+    await session.flush()
+    with pytest.MonkeyPatch.context() as monkey:
+        monkey.setattr("dealfinder.agents.scanner.feedparser.parse", lambda _: feed)
+        new_deals = await scanner.scan_source(source, session)
+    await session.commit()
+    deal = new_deals[0]
+    await session.refresh(deal)
+    return deal
+
+
+async def _patch_evaluator_dependencies(
+    monkeypatch,
+    regression_session_factory,
+    queue_stub: _StubQueue,
+    saved_feeds: list[dict[str, str]],
+):
+    class _DummyUser:
+        def __init__(self, feeds: list[dict[str, str]]) -> None:
+            self.id = uuid4()
+            self.notification_preferences = {"saved_feeds": feeds}
+
+    async def _fake_find_active_users(self):
+        return [_DummyUser(saved_feeds)]
+
+    monkeypatch.setattr(
+        "dealfinder.agents.evaluator.UserRepository.find_active_users",
+        _fake_find_active_users,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "dealfinder.agents.evaluator.get_async_session",
+        lambda: _SessionContext(regression_session_factory),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "dealfinder.agents.evaluator.boto3.client",
+        lambda *_args, **_kwargs: queue_stub,
+    )
+
+
+async def _verify_deal_status(regression_session_factory, deal_id):
+    async with _SessionContext(regression_session_factory) as session:
+        repo = DealRepository(session)
+        refreshed = await repo.get_by_id(deal_id)
+        assert refreshed is not None
+        return refreshed
+
+
+async def _reset_tables(regression_session_factory):
+    async with _SessionContext(regression_session_factory) as session:
+        await session.execute(text("DELETE FROM notifications"))
+        await session.execute(text("DELETE FROM price_estimates"))
+        await session.execute(text("DELETE FROM deals"))
+        await session.execute(text("DELETE FROM deal_sources"))
+
+
+async def test_high_value_deal_triggers_notification_queue(
+    regression_session_factory,
+    monkeypatch,
+    pipeline_env_variables,
+):
+    await _reset_tables(regression_session_factory)
+    async with _SessionContext(regression_session_factory) as session:
+        source = _prepare_source(session, "Regression Feed HV", "https://example.com/feed/high")
+        await session.commit()
+        await session.refresh(source)
+        deal = await _create_pipeline_deal(
+            session, source, "Mega Laptop Deal", "https://example.com/deals/high"
+        )
+        deal.sale_price = Decimal("100")
+        deal.original_price = Decimal("300")
+        await session.commit()
+        deal_id = deal.id
+
+    queue_stub = _StubQueue()
+    saved_feeds = [{"id": "feed-laptop", "query": "Mega Laptop"}]
+    await _patch_evaluator_dependencies(
+        monkeypatch, regression_session_factory, queue_stub, saved_feeds
+    )
+
+    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=20.0)
+    evaluator = EvaluatorAgent(config=config)
+    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("400"))
+
+    result = await evaluator.evaluate_deal(deal_id)
+
+    assert result["status"] == "evaluated"
+    assert result["is_high_value"] is True
+    assert result["discount_percentage"] == pytest.approx(75.0, rel=1e-6)
+    assert queue_stub.messages, "Expected SQS message for high-value deal"
+    message = queue_stub.messages[0]
+    assert message["QueueUrl"] == pipeline_env_variables["sqs_queue_url"]
+    assert json.loads(message["MessageBody"])["deal_id"] == str(deal_id)
+    assert result["matched_feed_pairs"]
+    refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
+    assert refreshed_deal.status == DealStatus.EVALUATED
+    assert refreshed_deal.is_high_value is True
+    assert refreshed_deal.discount_percentage is not None
+
+
+async def test_sub_threshold_deal_skips_notification_queue(
+    regression_session_factory,
+    monkeypatch,
+    pipeline_env_variables,
+):
+    await _reset_tables(regression_session_factory)
+    async with _SessionContext(regression_session_factory) as session:
+        source = _prepare_source(session, "Regression Feed LV", "https://example.com/feed/low")
+        await session.commit()
+        await session.refresh(source)
+        deal = await _create_pipeline_deal(
+            session, source, "Budget Mouse Deal", "https://example.com/deals/low"
+        )
+        deal.sale_price = Decimal("95")
+        deal.original_price = Decimal("100")
+        await session.commit()
+        deal_id = deal.id
+
+    queue_stub = _StubQueue()
+    saved_feeds = [{"id": "feed-mouse", "query": "Office Chair"}]
+    await _patch_evaluator_dependencies(
+        monkeypatch, regression_session_factory, queue_stub, saved_feeds
+    )
+
+    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=20.0)
+    evaluator = EvaluatorAgent(config=config)
+    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("105"))
+
+    result = await evaluator.evaluate_deal(deal_id)
+
+    assert result["status"] == "evaluated"
+    assert result["is_high_value"] is False
+    assert result["matched_feed_pairs"] == []
+    assert queue_stub.messages == [], "No SQS messages should be sent for sub-threshold deals"
+    refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
+    assert refreshed_deal.status == DealStatus.EVALUATED
+    assert refreshed_deal.is_high_value is False
+    assert refreshed_deal.discount_percentage is not None
+    assert refreshed_deal.discount_percentage < Decimal("20")
+
+
+async def test_watchlist_dedup_sends_single_notification(
+    regression_session_factory,
+    monkeypatch,
+    pipeline_env_variables,
+):
+    await _reset_tables(regression_session_factory)
+    async with _SessionContext(regression_session_factory) as session:
+        source = _prepare_source(session, "Regression Feed WL", "https://example.com/feed/watch")
+        await session.commit()
+        await session.refresh(source)
+        deal = await _create_pipeline_deal(
+            session, source, "Ultimate Gaming Rig", "https://example.com/deals/watch"
+        )
+        deal.sale_price = Decimal("500")
+        deal.original_price = Decimal("1200")
+        await session.commit()
+        deal_id = deal.id
+
+    queue_stub = _StubQueue()
+    saved_feeds = [
+        {"id": "feed-gaming-1", "query": "Ultimate Gaming"},
+        {"id": "feed-gaming-2", "query": "Gaming Rig Ultimate"},
+        {"id": "feed-miss", "query": "Office Chair"},
+    ]
+    await _patch_evaluator_dependencies(
+        monkeypatch, regression_session_factory, queue_stub, saved_feeds
+    )
+
+    config = _build_agent_config(pipeline_env_variables["sqs_queue_url"], discount_threshold=25.0)
+    evaluator = EvaluatorAgent(config=config)
+    evaluator.estimator = _prepare_estimator(estimated_price=Decimal("1500"))
+
+    result = await evaluator.evaluate_deal(deal_id)
+
+    assert result["is_high_value"] is True
+    assert len(result["matched_feed_pairs"]) == 2
+    assert len(queue_stub.messages) == 1, "Queue should receive a single message per deal"
+    message_body = json.loads(queue_stub.messages[0]["MessageBody"])
+    assert message_body["deal_id"] == str(deal_id)
+    refreshed_deal = await _verify_deal_status(regression_session_factory, deal_id)
+    assert refreshed_deal.is_high_value is True

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,6 @@ dependencies = [
     { name = "feedparser" },
     { name = "httpx" },
     { name = "mangum" },
-    { name = "moto" },
     { name = "opensearch-dsl" },
     { name = "opensearch-py" },
     { name = "psycopg2-binary" },
@@ -458,6 +457,7 @@ dev = [
 dev = [
     { name = "aiosqlite" },
     { name = "httpx" },
+    { name = "moto" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -475,7 +475,6 @@ requires-dist = [
     { name = "feedparser", specifier = "==6.0.12" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mangum", specifier = ">=0.19.0" },
-    { name = "moto", specifier = ">=5.1.22" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "opensearch-dsl", specifier = ">=2.1.0" },
     { name = "opensearch-py", specifier = ">=2.4.0" },
@@ -495,6 +494,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "moto", specifier = ">=5.1.22" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -310,6 +367,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+]
+
+[[package]]
 name = "dealfinder"
 version = "0.4.0"
 source = { editable = "." }
@@ -323,6 +433,7 @@ dependencies = [
     { name = "feedparser" },
     { name = "httpx" },
     { name = "mangum" },
+    { name = "moto" },
     { name = "opensearch-dsl" },
     { name = "opensearch-py" },
     { name = "psycopg2-binary" },
@@ -364,6 +475,7 @@ requires-dist = [
     { name = "feedparser", specifier = "==6.0.12" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mangum", specifier = ">=0.19.0" },
+    { name = "moto", specifier = ">=5.1.22" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "opensearch-dsl", specifier = ">=2.1.0" },
     { name = "opensearch-py", specifier = ">=2.4.0" },
@@ -584,6 +696,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -729,6 +853,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
 ]
 
 [[package]]
@@ -906,6 +1050,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1138,6 +1291,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1291,4 +1458,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
- add tests/regression pipeline smoke scenarios
## Summary
This pull request introduces a regression testing suite that exercises the end-to-end deal pipeline, ensuring critical flows stay stable as we iterate on the codebase. The focus is on protecting against regressions in scanning, evaluation, notification gating, and watchlist enrichment.

## Motivation
- Frequent changes to Lambda agents and shared repositories have increased the risk of silent breakage in critical flows.
- Recent fixes (e.g., deterministic external IDs, SES opt-in gating) should remain guarded by automated checks.
- Establishing a reusable regression harness will accelerate release confidence.

## What’s Included
- Added pytest scenarios that traverse Scanner → Evaluator → Messenger → Watchlist interactions using in-memory SQLite and moto-stubbed AWS clients.
- Captured baseline fixtures for high-value and low-value deal outcomes, including DynamoDB state assertions.
- Documented the regression command in the developer journal appendix and PROCESS_FLOWS notes.
- Hooked the regression suite into CI so failures block merges targeting production branches.

## Testing
- [x] `uv run pytest tests/regression -q`
- [x] `uv run pytest tests/unit -q`
- [x] `uv run pytest tests/integration -q`
- [x] `npm run test` (frontend sanity)
- [ ] Manual Step Functions execution (not required for this change)

## Checklist
- [x] Tests created/updated to cover new scenarios
- [x] Documentation refreshed (`developer/developer_journal.md`, regression command reference)
- [x] No secrets or feature flags hardcoded
- [x] Conventional commit message prepared
- [ ] Deployment runbook updated (pending—will bundle with next infra change)

## Risks & Mitigations
| Risk | Mitigation |
|------|------------|
| Longer CI runtime due to regression suite | Parallelize pytest jobs; suite limited to high-value paths |
| Flaky network-bound tests | All external calls mocked/stubbed; deterministic fixtures |
| Overlapping data fixtures | Namespaced fixtures per suite and shared factory utilities |

## Notes for Reviewers
- Focus review on the regression fixture patterns; feedback welcome on making them easier to extend.
- Verify the CI workflow change keeps total runtime under the current SLA (~12 minutes).
- Future work: add smoke coverage for SES production access once AWS approves the limit increase.- document the regression run in developer journal and AGENTS guide

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a regression test suite (`tests/regression/`) that exercises the end-to-end deal pipeline — Scanner → Evaluator → SQS notification — using an in-memory SQLite database and `mock_aws`-stubbed AWS clients. It also includes minor docstring and code-formatting improvements to `bedrock.py` and `config.py`, moves `moto` correctly into the `[dependency-groups] dev` block, and adds documentation updates to `AGENTS.md`, `README.md`, and the developer journal.

Key observations:

- **High-value and dedup tests are solid**: `test_high_value_deal_triggers_notification_queue` and `test_watchlist_dedup_sends_single_notification` correctly exercise their stated paths end-to-end with real moto SQS assertions.
- **Sub-threshold test conflates gate conditions** (previously flagged): `test_sub_threshold_deal_skips_notification_queue` uses a saved-feed query (`"Office Chair"`) that doesn't match the deal title (`"Budget Mouse Deal"`), so the SQS message is suppressed by the feed-match gate, not the discount threshold. A bug that removed the threshold check entirely would still pass this test.
- **`_SessionContext.__aexit__` missing `finally`**: If `commit()` or `rollback()` raises, `close()` is never called, leaving the shared `StaticPool` connection open. This is a new finding not covered by prior review threads.
- **`db_session` fixture unused** (previously flagged): Declared in `conftest.py` but not requested by any test.
- **Module docstring placement** (previously flagged): The `conftest.py` docstring appears after imports and won't be recognised by tooling.
- `moto` is correctly placed in dev dependencies and is actively used via `with mock_aws():` in all three tests.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for CI coverage purposes, but the sub-threshold test provides a false sense of security for the discount-threshold gate.
- The high-value and dedup test paths are well-structured and correctly verified. However, the sub-threshold test does not actually exercise the discount threshold gate — a threshold regression would go undetected. Combined with the `_SessionContext` close-leak and the unused `db_session` fixture, the suite has meaningful gaps in both correctness and robustness for test infrastructure that is intended to block production merges.
- tests/regression/test_deal_pipeline.py — specifically `test_sub_threshold_deal_skips_notification_queue` (wrong gate exercised) and `_SessionContext.__aexit__` (missing `finally`).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/regression/test_deal_pipeline.py | Core regression suite with three pipeline tests. The high-value and dedup scenarios are well-structured and use `mock_aws` correctly. The sub-threshold test (`test_sub_threshold_deal_skips_notification_queue`) suppresses the SQS message via a feed-query mismatch rather than the discount gate, so the threshold check itself is not guarded. `_SessionContext.__aexit__` is missing a `finally` around `close()`, leaving the shared StaticPool connection open on error. |
| tests/regression/conftest.py | Shared fixtures for the regression suite. `sqlite_engine` correctly enables foreign keys and registers `Base.metadata`. `db_session` fixture is defined but not requested by any test — it's dead fixture weight. Module docstring is placed after imports (already flagged in prior review thread) so tooling won't recognise it. |
| tests/regression/jsonb_patch.py | Clean SQLite JSONB compiler shim. The `@compiles` hook runs once on import; `enable_sqlite_jsonb_support()` is a safe no-op callable for call sites that expect a function. No issues found. |
| pyproject.toml | `moto>=5.1.22` correctly added to `[dependency-groups] dev` — not to production dependencies. No issues. |
| src/dealfinder/agents/bedrock.py | Pure docstring and code-formatting improvements (type annotations in docstrings, multi-line dict literals, quote-style consistency). No functional changes. No issues. |
| src/dealfinder/agents/config.py | Docstring reformatted to use Google-style typed attributes; `tavily_api_key` added to the attribute list. No functional changes. No issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant ScannerAgent
    participant EvaluatorAgent
    participant MockEstimator
    participant SQLite as SQLite (StaticPool)
    participant SQS as SQS (mock_aws)

    Test->>SQLite: INSERT DealSource
    Test->>ScannerAgent: scan_source(source, session)
    ScannerAgent->>SQLite: INSERT Deal (DISCOVERED)
    Test->>SQLite: UPDATE deal.sale_price / original_price

    Test->>EvaluatorAgent: evaluate_deal(deal_id)
    EvaluatorAgent->>SQLite: GET Deal, UPDATE status → EVALUATING
    EvaluatorAgent->>MockEstimator: estimate_price(title, sale_price, ...)
    MockEstimator-->>EvaluatorAgent: PriceEstimationResult
    EvaluatorAgent->>SQLite: INSERT PriceEstimate
    EvaluatorAgent->>SQLite: UPDATE Deal → EVALUATED, is_high_value, discount_pct

    EvaluatorAgent->>EvaluatorAgent: _notify_watchlist_matches()
    EvaluatorAgent->>SQLite: find_active_users() [patched → _DummyUser]
    EvaluatorAgent->>EvaluatorAgent: keyword match deal.title vs saved_feeds
    alt feed match found
        EvaluatorAgent->>SQS: send_message({deal_id})
    else no match
        EvaluatorAgent-->>Test: matched_feed_pairs = []
    end
    EvaluatorAgent-->>Test: result dict

    Test->>SQS: receive_message()
    Test->>SQLite: verify Deal.status / is_high_value / discount_pct
```

<sub>Last reviewed commit: 5e5278f</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->