### PR TITLE
PR - Bug: Removing watchlist item does not remove associated deals from Top Deals

### DIFF
--- a/frontend/src/api/deals.ts
+++ b/frontend/src/api/deals.ts
@@ -8,8 +8,12 @@ export async function listDeals(filters: DealFilters = {}): Promise<DealListResp
 }
 
 /** GET /api/v1/deals/top — high-value deals sorted by discount. */
-export async function topDeals(limit = 20): Promise<DealResponse[]> {
-  const { data } = await apiClient.get<DealResponse[]>('/deals/top', { params: { limit } });
+export async function topDeals(limit = 20, minDiscount?: number): Promise<DealResponse[]> {
+  const params: Record<string, number> = { limit };
+  if (minDiscount != null && minDiscount > 0) {
+    params.min_discount = minDiscount;
+  }
+  const { data } = await apiClient.get<DealResponse[]>('/deals/top', { params });
   return data;
 }
 

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -12,10 +12,11 @@ export function useDeals(filters: DealFilters = {}, options?: { enabled?: boolea
   });
 }
 
-export function useTopDeals(limit = 20, minDiscount?: number) {
+export function useTopDeals(limit = 20, minDiscount?: number, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['deals', 'top', limit, minDiscount],
     queryFn: () => topDeals(limit, minDiscount),
+    enabled: options?.enabled,
   });
 }
 

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -12,10 +12,10 @@ export function useDeals(filters: DealFilters = {}, options?: { enabled?: boolea
   });
 }
 
-export function useTopDeals(limit = 20) {
+export function useTopDeals(limit = 20, minDiscount?: number) {
   return useQuery({
-    queryKey: ['deals', 'top', limit],
-    queryFn: () => topDeals(limit),
+    queryKey: ['deals', 'top', limit, minDiscount],
+    queryFn: () => topDeals(limit, minDiscount),
   });
 }
 
@@ -43,6 +43,9 @@ export function useUpdatePreferences(userId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['user', userId] });
       queryClient.invalidateQueries({ queryKey: ['watchlist-matches', userId] });
+      // Removing a watchlist feed deletes orphaned deals on the backend,
+      // so top deals and the main deals list must be refreshed.
+      queryClient.invalidateQueries({ queryKey: ['deals'] });
     },
   });
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -233,6 +233,8 @@ h1 { font-size: 1.6rem; font-weight: 700; margin-top: 0; }
   background: var(--c-surface);
 }
 .form-input:focus { outline: 2px solid var(--c-primary); outline-offset: 1px; }
+.form-range { width: 100%; accent-color: var(--c-primary); cursor: pointer; margin-top: .25rem; }
+.range-labels { display: flex; justify-content: space-between; font-size: .75rem; color: var(--c-muted); }
 .form-feedback { font-size: .875rem; padding: .5rem .75rem; border-radius: var(--radius); }
 .form-feedback--ok { background: #d1e7dd; color: var(--c-success); }
 .form-feedback--error { background: #f8d7da; color: var(--c-danger); }

--- a/frontend/src/pages/PreferencesPage.tsx
+++ b/frontend/src/pages/PreferencesPage.tsx
@@ -19,6 +19,7 @@ export function PreferencesPage() {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [phoneError, setPhoneError] = useState('');
   const [emailEnabled, setEmailEnabled] = useState(false);
+  const [minDiscount, setMinDiscount] = useState(20);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteMsg, setDeleteMsg] = useState('');
 
@@ -27,6 +28,8 @@ export function PreferencesPage() {
     if (!existing) return;
     if (existing.phone_number) setPhoneNumber(existing.phone_number);
     setEmailEnabled(existing.notification_preferences?.email === true);
+    const saved = existing.notification_preferences?.min_discount_percentage;
+    if (typeof saved === 'number') setMinDiscount(saved);
   }, [existing]);
 
   function handleSubmit(e: React.FormEvent) {
@@ -39,7 +42,7 @@ export function PreferencesPage() {
     }
     mutate({
       phone_number: phone || null,
-      notification_preferences: { email: emailEnabled },
+      notification_preferences: { email: emailEnabled, min_discount_percentage: minDiscount },
     });
   }
 
@@ -73,6 +76,30 @@ export function PreferencesPage() {
             onChange={(e) => setEmailEnabled(e.target.checked)}
           />
           Enable email notifications
+        </label>
+      </section>
+
+      {/* ──── Top Deals Threshold */}
+      <section className="pref-section">
+        <h2>Top Deals Threshold</h2>
+        <p className="section-subtitle">
+          Only show deals on the Top Deals page with at least this discount percentage.
+        </p>
+        <label className="form-label">
+          Minimum discount: <strong>{minDiscount}%</strong>
+          <input
+            type="range"
+            min={0}
+            max={80}
+            step={5}
+            value={minDiscount}
+            onChange={(e) => setMinDiscount(Number(e.target.value))}
+            className="form-range"
+          />
+          <span className="range-labels">
+            <span>0%</span>
+            <span>80%</span>
+          </span>
         </label>
       </section>
 

--- a/frontend/src/pages/TopDealsPage.tsx
+++ b/frontend/src/pages/TopDealsPage.tsx
@@ -6,13 +6,15 @@ import { isAuthenticated, getUserId } from '../auth';
 export function TopDealsPage() {
   const authed = isAuthenticated();
   const userId = getUserId() ?? '';
-  const { data: userPrefs } = useUserPreferences(authed ? userId : '');
+  const { data: userPrefs, isLoading: prefsLoading } = useUserPreferences(authed ? userId : '');
 
   const minDiscount = typeof userPrefs?.notification_preferences?.min_discount_percentage === 'number'
     ? (userPrefs.notification_preferences.min_discount_percentage as number)
     : undefined;
 
-  const { data, isLoading, isError } = useTopDeals(20, minDiscount);
+  const { data, isLoading, isError } = useTopDeals(20, minDiscount, {
+    enabled: !authed || !prefsLoading,
+  });
 
   return (
     <div className="page">

--- a/frontend/src/pages/TopDealsPage.tsx
+++ b/frontend/src/pages/TopDealsPage.tsx
@@ -1,13 +1,30 @@
+import { Link } from 'react-router-dom';
 import { DealCard } from '../components/DealCard';
-import { useTopDeals } from '../hooks';
+import { useTopDeals, useUserPreferences } from '../hooks';
+import { isAuthenticated, getUserId } from '../auth';
 
 export function TopDealsPage() {
-  const { data, isLoading, isError } = useTopDeals(20);
+  const authed = isAuthenticated();
+  const userId = getUserId() ?? '';
+  const { data: userPrefs } = useUserPreferences(authed ? userId : '');
+
+  const minDiscount = typeof userPrefs?.notification_preferences?.min_discount_percentage === 'number'
+    ? (userPrefs.notification_preferences.min_discount_percentage as number)
+    : undefined;
+
+  const { data, isLoading, isError } = useTopDeals(20, minDiscount);
 
   return (
     <div className="page">
       <h1>🔥 Top Deals</h1>
-      <p className="page-subtitle">High-value deals sorted by discount percentage</p>
+      <p className="page-subtitle">
+        High-value deals sorted by discount percentage
+        {minDiscount != null && minDiscount > 0 && (
+          <> &mdash; filtered to ≥{minDiscount}% off.{' '}
+            <Link to="/preferences">Change</Link>
+          </>
+        )}
+      </p>
 
       {isLoading && <p className="state-msg">Loading…</p>}
       {isError && <p className="state-msg state-msg--error">Failed to load top deals.</p>}

--- a/src/dealfinder/api/routes/deals.py
+++ b/src/dealfinder/api/routes/deals.py
@@ -95,24 +95,32 @@ async def list_deals(
 @router.get("/top", response_model=list[DealResponse], summary="Top high-value deals")
 async def top_deals(
     limit: int = Query(20, ge=1, le=100),
+    min_discount: Optional[float] = Query(
+        None, ge=0, le=100, description="Minimum discount percentage filter",
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> list[DealResponse]:
     """Return high-value deals sorted by discount percentage descending.
 
     Args:
         limit: Maximum number of deals to return (default 20, max 100).
+        min_discount: Optional minimum discount percentage. When provided, only
+            deals with ``discount_percentage >= min_discount`` are returned.
         db: Injected database session.
 
     Returns:
         List of high-value deals sorted by discount percentage.
     """
-    result = await db.execute(
+    query = (
         select(Deal)
         .where(Deal.is_high_value == True)  # noqa: E712
-        .order_by(desc(Deal.discount_percentage))
-        .limit(limit)
         .options(selectinload(Deal.source))
     )
+    if min_discount is not None and min_discount > 0:
+        query = query.where(Deal.discount_percentage >= min_discount)
+    query = query.order_by(desc(Deal.discount_percentage)).limit(limit)
+
+    result = await db.execute(query)
     deals = result.scalars().all()
 
     return [

--- a/src/dealfinder/api/routes/users.py
+++ b/src/dealfinder/api/routes/users.py
@@ -258,16 +258,25 @@ async def update_preferences(
     message: str | None = None
     removed_count = 0
     if body.saved_feeds is not None:
+        old_queries = {f.get("query", "").lower().strip() for f in old_feeds}
+        new_queries = {f.get("query", "").lower().strip() for f in prefs["saved_feeds"]}
+        added = new_queries - old_queries
+        removed = old_queries - new_queries
+
         removed_count = await _cleanup_orphaned_watchlist_deals(
             old_feeds=old_feeds,
-            new_feeds=[f.model_dump() for f in body.saved_feeds],
+            new_feeds=prefs["saved_feeds"],
             current_user_id=user_id,
             db=db,
         )
         if removed_count > 0:
             message = f"Feed removed. {removed_count} associated deal(s) cleaned up."
-        else:
+        elif removed:
+            message = "Feed removed."
+        elif added:
             message = "Feed saved. New deals matching your watchlist will trigger notifications."
+        else:
+            message = "Preferences updated."
 
     return PreferencesUpdateResponse(
         **UserResponse.model_validate(user).model_dump(),

--- a/src/dealfinder/api/routes/users.py
+++ b/src/dealfinder/api/routes/users.py
@@ -16,7 +16,7 @@ from uuid import UUID
 import boto3
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import desc, func, or_, select
+from sqlalchemy import and_, delete, desc, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -234,6 +234,11 @@ async def update_preferences(
     repo = UserRepository(db)
     user = await _get_or_provision_user(user_id, token_claims, repo)
 
+    # Snapshot current feeds before updating so we can detect removals
+    old_feeds: list[dict] = list(
+        (user.notification_preferences or {}).get("saved_feeds", []) or []
+    )
+
     # Merge notification_preferences dict rather than replacing it wholesale
     prefs: dict = dict(user.notification_preferences or {})
     if body.notification_preferences is not None:
@@ -251,8 +256,18 @@ async def update_preferences(
     await db.refresh(user)
 
     message: str | None = None
+    removed_count = 0
     if body.saved_feeds is not None:
-        message = "Feed saved. New deals matching your watchlist will trigger notifications."
+        removed_count = await _cleanup_orphaned_watchlist_deals(
+            old_feeds=old_feeds,
+            new_feeds=[f.model_dump() for f in body.saved_feeds],
+            current_user_id=user_id,
+            db=db,
+        )
+        if removed_count > 0:
+            message = f"Feed removed. {removed_count} associated deal(s) cleaned up."
+        else:
+            message = "Feed saved. New deals matching your watchlist will trigger notifications."
 
     return PreferencesUpdateResponse(
         **UserResponse.model_validate(user).model_dump(),
@@ -418,6 +433,95 @@ async def watchlist_matches(
         last_scan_at=last_scan_at,
         sources_scanned=sources_scanned,
     )
+
+
+async def _cleanup_orphaned_watchlist_deals(
+    old_feeds: list[dict],
+    new_feeds: list[dict],
+    current_user_id: UUID,
+    db: AsyncSession,
+) -> int:
+    """Delete watchlist-sourced deals whose queries are no longer watched by any user.
+
+    Compares old and new saved_feeds to find removed queries, then checks whether
+    any other active user still references each query.  If a query is orphaned,
+    all deals from the corresponding ``watchlist://`` DealSource are deleted.
+
+    Args:
+        old_feeds: The user's saved_feeds list before the update.
+        new_feeds: The user's saved_feeds list after the update.
+        current_user_id: UUID of the user whose feeds changed.
+        db: Active database session.
+
+    Returns:
+        Total number of deals deleted.
+    """
+    old_queries = {f.get("query", "").lower().strip() for f in old_feeds if f.get("query")}
+    new_queries = {f.get("query", "").lower().strip() for f in new_feeds if f.get("query")}
+    removed_queries = old_queries - new_queries
+
+    if not removed_queries:
+        return 0
+
+    # Check if any OTHER active user still references each removed query
+    other_users_result = await db.execute(
+        select(User.notification_preferences)
+        .where(
+            and_(
+                User.id != current_user_id,
+                User.is_active == True,  # noqa: E712
+            )
+        )
+    )
+    other_prefs = other_users_result.scalars().all()
+
+    # Collect all queries still referenced by other users
+    still_watched: set[str] = set()
+    for prefs in other_prefs:
+        if not prefs:
+            continue
+        for feed in prefs.get("saved_feeds", []) or []:
+            if isinstance(feed, dict) and feed.get("query"):
+                still_watched.add(feed["query"].lower().strip())
+
+    orphaned_queries = removed_queries - still_watched
+    if not orphaned_queries:
+        return 0
+
+    total_deleted = 0
+    for query in orphaned_queries:
+        watchlist_url = f"watchlist://{query}"
+
+        # Find the DealSource for this watchlist query
+        source_result = await db.execute(
+            select(DealSource.id).where(DealSource.url == watchlist_url)
+        )
+        source_id = source_result.scalar_one_or_none()
+        if not source_id:
+            continue
+
+        # Delete deals from this source (cascades to price_estimates, notifications)
+        del_result = await db.execute(
+            delete(Deal).where(Deal.source_id == source_id)
+        )
+        deleted = del_result.rowcount
+        total_deleted += deleted
+
+        # Deactivate the orphaned DealSource
+        source_obj_result = await db.execute(
+            select(DealSource).where(DealSource.id == source_id)
+        )
+        source_obj = source_obj_result.scalar_one_or_none()
+        if source_obj:
+            source_obj.is_active = False
+
+        logger.info(
+            "Cleaned up %d deal(s) for orphaned watchlist query '%s'",
+            deleted,
+            query,
+        )
+
+    return total_deleted
 
 
 def _subscribe_phone_to_sns(phone_number: str) -> None:


### PR DESCRIPTION
fix(Top Deals Page): top deals not deleted when items removed from watch list

Closes #20

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the bug where removing a watchlist feed left its associated deals visible on the Top Deals page. It introduces a backend `_cleanup_orphaned_watchlist_deals` helper that deletes deals sourced from a `watchlist://` URL when no other active user still references that query, and deactivates the orphaned `DealSource`. On the frontend, preference saves now invalidate the deals cache, and a new `min_discount_percentage` preference (set via a range slider in Preferences) is forwarded to the `/deals/top` endpoint so users can personalise their Top Deals threshold.

**Key changes:**
- `users.py`: Snapshot `old_feeds` before the update, call cleanup helper after flush, and return a more descriptive success message based on what actually changed.
- `deals.py`: New optional `min_discount` query parameter on `GET /deals/top`.
- `hooks/index.ts`: `useTopDeals` gains `minDiscount` + `enabled` params; `useUpdatePreferences` now invalidates all `['deals']` queries on success.
- `TopDealsPage.tsx`: Guards the top-deals fetch until user preferences have loaded to avoid a flash of unfiltered results.
- `PreferencesPage.tsx`: Adds a range slider for the minimum discount threshold (0–80%).

**Issues found:**
- The `old_queries`/`new_queries` sets in `update_preferences` (lines 261–262) lack the `if f.get("query")` guard present in the helper, so feeds with a missing or empty `"query"` key can insert `""` into the sets and trigger the wrong success message branch.
- The cleanup loop issues two DB round-trips per orphaned query (first `SELECT DealSource.id`, then a second `SELECT DealSource`) where a single select of the full object suffices.
- `invalidateQueries({ queryKey: ['deals'] })` is a prefix match that also invalidates `useDeal` (individual deal detail) queries — narrowing to `['deals', 'top']` would be more targeted.
- The `minDiscount` state initialises to `20` in `PreferencesPage`, meaning a first-time save silently imposes a 20% filter on Top Deals without the user explicitly choosing it. Defaulting to `0` would be safer.

<h3>Confidence Score: 3/5</h3>

- Core fix is sound but a message-selection bug and a few performance improvements should be addressed before merging.
- The cleanup logic and frontend integration work correctly for the happy path. The empty-string guard inconsistency between the message-selection sets and the helper function is a real (if low-severity) bug that can display the wrong success message. The double-query loop and overly broad cache invalidation are performance concerns rather than correctness bugs. The default `minDiscount: 20` is a UX risk for new users. None of these are critical blockers, but the P1 message-selection issue warrants a fix before merging.
- `src/dealfinder/api/routes/users.py` — the `update_preferences` function's message-selection sets and the cleanup loop's double DB query need attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dealfinder/api/routes/users.py | Adds `_cleanup_orphaned_watchlist_deals` helper and integrates it into `update_preferences`. Two issues: empty-query feeds can leak `""` into message-selection sets (wrong message shown), and the cleanup loop makes two DB round-trips per orphaned query where one would suffice. |
| src/dealfinder/api/routes/deals.py | Adds optional `min_discount` query parameter to `/top` endpoint; filter is applied correctly and only when the value is non-null and > 0. |
| frontend/src/hooks/index.ts | Extends `useTopDeals` with `minDiscount` parameter and `enabled` option; adds `['deals']` invalidation on preference update. The broad prefix-match invalidation also triggers refetches on individual deal detail queries unnecessarily. |
| frontend/src/pages/TopDealsPage.tsx | Loads user preferences to derive `minDiscount` and guards `useTopDeals` with `enabled: !authed || !prefsLoading`, preventing a flash of unfiltered deals for authenticated users. Logic is sound. |
| frontend/src/pages/PreferencesPage.tsx | Adds a range slider for `min_discount_percentage`. The hardcoded default of `20` will silently write a 20% filter the first time any authenticated user saves their preferences, which may be unintentional. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (Browser)
    participant FE as PreferencesPage
    participant API as PUT /users/{id}/preferences
    participant DB as Database

    U->>FE: Remove watchlist feed & click Save
    FE->>API: PUT preferences (saved_feeds without removed feed)
    API->>DB: SELECT user.notification_preferences (snapshot old_feeds)
    API->>DB: FLUSH updated preferences
    API->>DB: SELECT all other active users' notification_preferences
    Note over API: Build still_watched set from other users
    API->>DB: SELECT DealSource.id WHERE url = 'watchlist://{query}'
    API->>DB: DELETE Deal WHERE source_id = source_id
    API->>DB: SELECT DealSource (to deactivate)
    API->>DB: UPDATE DealSource SET is_active = false
    API-->>FE: 200 OK { message: "Feed removed. N deal(s) cleaned up." }
    FE->>FE: invalidateQueries(['deals'])\ninvalidateQueries(['user', userId])\ninvalidateQueries(['watchlist-matches', userId])
    FE->>API: GET /deals/top (refetch)
    API-->>FE: Deals without orphaned watchlist deals
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/dealfinder/api/routes/users.py
Line: 261-262

Comment:
**Empty-string queries leak into message selection sets**

`old_queries` and `new_queries` here are built without the `if f.get("query")` guard that `_cleanup_orphaned_watchlist_deals` uses (lines 468–469). Any feed dict that is missing the `"query"` key — or has an empty string — contributes `""` to both sets. If the two sets differ in that empty-string sentinel (e.g. a legacy feed had no `"query"` key), `removed` or `added` will be truthy and the wrong success message branch fires.

The helper already handles this safely; reuse its pattern here:

```suggestion
        old_queries = {f.get("query", "").lower().strip() for f in old_feeds if f.get("query")}
        new_queries = {f.get("query", "").lower().strip() for f in prefs["saved_feeds"] if f.get("query")}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/dealfinder/api/routes/users.py
Line: 504-524

Comment:
**Two round-trips to load the same `DealSource` row**

For each orphaned query the loop first selects only `DealSource.id`, then immediately issues a second `SELECT` for the full `DealSource` object using that `id`. These can be collapsed into one query:

```python
        source_result = await db.execute(
            select(DealSource).where(DealSource.url == watchlist_url)
        )
        source_obj = source_result.scalar_one_or_none()
        if not source_obj:
            continue
        source_id = source_obj.id

        del_result = await db.execute(
            delete(Deal).where(Deal.source_id == source_id)
        )
        deleted = del_result.rowcount
        total_deleted += deleted

        source_obj.is_active = False
```

This halves the number of DB round-trips when multiple orphaned queries are cleaned up at once.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/hooks/index.ts
Line: 49

Comment:
**Overly broad cache invalidation hits individual deal detail queries**

`invalidateQueries({ queryKey: ['deals'] })` is a prefix-match — it also invalidates `['deals', <uuid>]` keys produced by `useDeal`, causing any currently-rendered deal detail page to silently refetch. Narrowing to only the list-level queries avoids the unnecessary round-trips:

```suggestion
      queryClient.invalidateQueries({ queryKey: ['deals', 'top'] });
      queryClient.invalidateQueries({ queryKey: ['deals', {}] }); // list queries
```

Or, if you intentionally want every deals-related query to refresh, the current single-line approach is fine — just be aware that individual deal detail views will refetch as well.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/pages/PreferencesPage.tsx
Line: 22

Comment:
**Hardcoded default silently filters Top Deals for new users**

`useState(20)` means that any user who has never explicitly set a minimum discount will see `20%` pre-selected in the form. The first time they click **Save** (e.g. to enable email notifications), `min_discount_percentage: 20` is written to their preferences without them knowingly choosing it. The Top Deals page will then silently filter out deals under 20% discount.

Consider initialising to `0` instead:

```suggestion
  const [minDiscount, setMinDiscount] = useState(0);
```

This way the slider still updates correctly from saved preferences via the `useEffect`, but a first-time save doesn't impose an invisible filter.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fixes(PR #21): on co..."](https://github.com/bytes0211/dealfinder/commit/a503395d770a719425f4a3f2bf8c71cec907d4ed)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->